### PR TITLE
Statically link all dependencies

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -11,7 +11,7 @@ build() {
   # $3 -> OS alias, used in the output file name
   # $4 -> Optional extension with ".", e.g.: .exe
   PACKAGE_FILE=$BASE_PACKAGE/spa-server_$3_$2$4
-  GOOS=$1 GOARCH=$2 go build -o $PACKAGE_FILE ./cmd
+  CGO_ENABLED=0 GOOS=$1 GOARCH=$2 go build -a -installsuffix cgo -o $PACKAGE_FILE ./cmd
 }
 
 build darwin amd64 mac


### PR DESCRIPTION
When creating a Docker image using `FROM scratch`, running the application fails with the following error:
```
$ docker run a9cff591a7a1
standard_init_linux.go:211: exec user process caused "no such file or directory"
```

It turns out that it is because the binary does not contain all the world and dynamically link to standard libraries. Which fail on a completely empty environment.

Compiling it with all libraries statically linked, fixes this issue.